### PR TITLE
Add Cache Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ typings/
 
 # Serverless directories
 .serverless
+
+# Budou cache
+budou-cache

--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
   "dependencies": {
     "@google-cloud/language": "^1.2.0",
     "jsdom": "^11.12.0",
+    "lowdb": "^1.0.0",
+    "pkg-dir": "^3.0.0",
     "unicode": "^11.0.1"
   },
   "devDependencies": {
     "jest": "^23.4.2",
     "prettier-standard": "^8.0.1"
   },
-  "engines" : {
+  "engines": {
     "node": ">=6.14.0"
   },
   "eslintConfig": {

--- a/src/cache.js
+++ b/src/cache.js
@@ -9,7 +9,6 @@ const CACHE_SALT = '2018-08-11'
 const DEFAULT_FILE_PATH = './budou-cache'
 
 class BudouCache {
-  static 
   get (source, language) {}
   set (source, language, value) {}
 
@@ -20,7 +19,10 @@ class BudouCache {
    */
   _getCacheKey (source, language = '') {
     const keySource = `${CACHE_SALT}:${source}:${language}`
-    return crypto.createHash('md5').update(keySource).digest('hex')
+    return crypto
+      .createHash('md5')
+      .update(keySource)
+      .digest('hex')
   }
 }
 
@@ -54,7 +56,7 @@ class LowCache extends BudouCache {
   _initDb () {
     if (!this.db) {
       const jsonPath = this._getCacheFilepath()
-  
+
       this.db = low(new FileSync(jsonPath))
       this.db.defaults({}).write()
     }

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,64 @@
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const pkgDir = require('pkg-dir')
+const low = require('lowdb')
+const FileSync = require('lowdb/adapters/FileSync')
+
+const CACHE_SALT = '2018-08-11'
+const DEFAULT_FILE_PATH = './budou-cache'
+
+class BudouCache {
+  static 
+  get (source, language) {}
+  set (source, language, value) {}
+
+  /**
+   * Returns a cache key for the given source and language
+   * @param {String} source Text to parse
+   * @param {String} [language=''] language of text
+   */
+  _getCacheKey (source, language = '') {
+    const keySource = `${CACHE_SALT}:${source}:${language}`
+    return crypto.createHash('md5').update(keySource).digest('hex')
+  }
+}
+
+class LowCache extends BudouCache {
+  constructor (filepath) {
+    super()
+    this.filepath = filepath || DEFAULT_FILE_PATH
+  }
+
+  get (source, language) {
+    this._initDb()
+    const cacheKey = this._getCacheKey(source, language)
+    return this.db.get(cacheKey).value()
+  }
+
+  set (source, language, value) {
+    this._initDb()
+    const cacheKey = this._getCacheKey(source, language)
+    return this.db.set(cacheKey, value).write()
+  }
+
+  _getCacheFilepath () {
+    const cacheDir = path.resolve(pkgDir.sync(__dirname), this.filepath)
+    const cacheFile = path.resolve(cacheDir, './cache.json')
+    if (!fs.existsSync(cacheDir)) {
+      fs.mkdirSync(cacheDir)
+    }
+    return cacheFile
+  }
+
+  _initDb () {
+    if (!this.db) {
+      const jsonPath = this._getCacheFilepath()
+  
+      this.db = low(new FileSync(jsonPath))
+      this.db.defaults({}).write()
+    }
+  }
+}
+
+module.exports = LowCache

--- a/tests/budou.test.js
+++ b/tests/budou.test.js
@@ -231,10 +231,9 @@ describe('Budou.parse', () => {
       // Mocks external getAnnotations Google API request
       parser._getAnnotations.mockReturnValueOnce(Promise.resolve({ tokens }))
 
-      const assertion = parser.parse(sentence, { language, useCache: false })
-        .then(({ chunks }) => {
-          expect(chunks.map(chunk => chunk.word)).toEqual(expected)
-        })
+      const assertion = parser.parse(sentence, { language, useCache: false }).then(({ chunks }) => {
+        expect(chunks.map(chunk => chunk.word)).toEqual(expected)
+      })
       assertions.push(assertion)
     }
 
@@ -255,13 +254,15 @@ describe('Budou.parse', () => {
       parser._getAnnotations.mockReturnValueOnce(Promise.resolve({ tokens }))
       parser._getEntities.mockReturnValueOnce(Promise.resolve(entities))
 
-     const assertion = parser.parse(sentence, {
-        language,
-        useCache: false,
-        useEntity: true
-      }).then(({ chunks }) => {
-        expect(chunks.map(chunk => chunk.word)).toEqual(expected_with_entity)
-      })
+      const assertion = parser
+        .parse(sentence, {
+          language,
+          useCache: false,
+          useEntity: true
+        })
+        .then(({ chunks }) => {
+          expect(chunks.map(chunk => chunk.word)).toEqual(expected_with_entity)
+        })
       assertions.push(assertion)
     }
 

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs')
+const path = require('path')
+const Cache = require('../src/cache')
+const cacheDir = path.resolve(__dirname, '../budou-cache')
+const cacheFile = path.resolve(cacheDir, './cache.json')
+const removeCache = () => {
+  if (fs.existsSync(cacheDir)) {
+    if (fs.existsSync(cacheFile)) {
+      fs.unlinkSync(cacheFile)
+    }
+    fs.rmdirSync(cacheDir)
+  }
+}
+
+describe('cache.get and cache.set', () => {
+  const cache = new Cache()
+  const source = 'apple'
+  const language = 'a'
+  const result = 'banana'
+
+  cache.set(source, language, result)
+
+  afterAll(() => {
+    removeCache()
+  })
+
+  test('Cache file should be generated', () => {
+    expect(fs.existsSync(cacheFile)).toBe(true)
+  })
+
+  test('The result should be cached', () => {
+    expect(cache.get(source, language)).toEqual(result)
+  })
+})
+
+describe('cache key', () => {
+  const cache = new Cache()
+  cache.set('a', 'en', 1)
+  cache.set('a', 'ja', 2)
+  cache.set('b', 'en', 3)
+
+  afterAll(() => {
+    removeCache()
+  })
+
+  test('The cached key should be unique per source text', () => {
+    expect(cache.get('a', 'en')).not.toEqual(cache.get('b', 'en'))
+  })
+
+  test('The cached key should be unique per language', () => {
+    expect(cache.get('a', 'en')).not.toEqual(cache.get('a', 'ja'))
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,6 +1394,12 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
+
 flat-cache@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
@@ -1648,7 +1654,7 @@ google-proto-files@^0.15.0:
     power-assert "^1.4.4"
     protobufjs "^6.8.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2615,6 +2621,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
@@ -2635,7 +2648,7 @@ lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
+lodash@4, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -2667,6 +2680,16 @@ loose-envify@^1.0.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lowdb@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lowdb/-/lowdb-1.0.0.tgz#5243be6b22786ccce30e50c9a33eac36b20c8064"
+  dependencies:
+    graceful-fs "^4.1.3"
+    is-promise "^2.1.0"
+    lodash "4"
+    pify "^3.0.0"
+    steno "^0.4.1"
 
 lru-cache@^4.0.1, lru-cache@^4.1.3:
   version "4.1.3"
@@ -3086,15 +3109,31 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -3190,6 +3229,12 @@ pkg-dir@^2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  dependencies:
+    find-up "^3.0.0"
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -3868,6 +3913,12 @@ static-extend@^0.1.1:
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
+steno@^0.4.1:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/steno/-/steno-0.4.4.tgz#071105bdfc286e6615c0403c27e9d7b5dcb855cb"
+  dependencies:
+    graceful-fs "^4.1.3"
 
 stream-shift@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Add caching support (#1 ) to `budou-node`. Enabled by default. 
Persists to file system in dir `budou-cache` at project root. 

If another matching source text and language is passed to `Budou.parse()` it will retrieve from the existing cache and prevent additional API calls to the Google Cloud API. 

I struggled to find a decent node caching library that persists to the file system. I opted for installing dependency [`lowdb`](https://github.com/typicode/lowdb) and wrote a simple wrapper class around it matching the implementation at https://github.com/google/budou/blob/master/budou/cachefactory.py.