### PR TITLE
Remove JSDOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   },
   "dependencies": {
     "@google-cloud/language": "^1.2.0",
+    "escape-html": "^1.0.3",
     "lowdb": "^1.0.0",
     "pkg-dir": "^3.0.0",
+    "striptags": "^3.1.1",
     "unicode": "^11.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@google-cloud/language": "^1.2.0",
-    "jsdom": "^11.12.0",
     "lowdb": "^1.0.0",
     "pkg-dir": "^3.0.0",
     "unicode": "^11.0.1"

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 const unicodePs = require('unicode/category/Ps')
 const unicodePi = require('unicode/category/Pi')
+const escapeHtml = require('escape-html')
 
 /**
  * Checks if the char belongs to Ps or Pi unicode categories
@@ -35,7 +36,24 @@ const hasCjk = chars =>
     return CJK_RANGES.some(range => range[0] <= code && range[1] >= code)
   })
 
+/**
+ * Creates an html string of element with specified attributes and innerHtml
+ *
+ * @param {String} tag The tag name of element
+ * @param {String} [innerHtml=''] The html content of element
+ * @param {Object} [attributes={}] key/value pairs of the html attributes
+ * @return {String} The processed html element string
+ */
+const createElementString = (tag, innerHtml = '', attributes = {}) => {
+  const attributesStr = Object.keys(attributes)
+    .map(key => ` ${key}="${attributes[key]}"`)
+    .join('')
+
+  return `<${tag}${attributesStr}>${innerHtml}</${tag}>`
+}
+
 module.exports = {
-  isOpenPunctuationChar,
-  hasCjk
+  createElementString,
+  hasCjk,
+  isOpenPunctuationChar
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,4 +1,4 @@
-const { hasCjk, isOpenPunctuationChar } = require('../src/utils')
+const { createElementString, hasCjk, isOpenPunctuationChar } = require('../src/utils')
 
 // @todo Use generator function to build random strings for ranges?
 const CHINESE_DUMMY_TEXT = '能記安全償与属護月孫支人受。'
@@ -36,5 +36,24 @@ describe('isOpenPunctuationChar', () => {
     testCharacters.forEach((char, index) => {
       expect(isOpenPunctuationChar(char)).toEqual(expectedResults[index])
     })
+  })
+})
+
+describe('createElementString', () => {
+  test('should correctly create html string for given tag', () => {
+    const expected = '<foo></foo>'
+    expect(createElementString('foo')).toEqual(expected)
+    const expectedWithContent = '<foo>bar</foo>'
+    expect(createElementString('foo', 'bar')).toEqual(expectedWithContent)
+  })
+
+  test('should correctly output the given html attributes', () => {
+    const expected = '<foo class="bar" custom="value">bar</foo>'
+    expect(createElementString('foo', 'bar', { class: 'bar', custom: 'value' })).toEqual(expected)
+  })
+
+  test('should not escape html content', () => {
+    const expected = '<foo><div><script>alert(1)</script></div></foo>'
+    expect(createElementString('foo', '<div><script>alert(1)</script></div>')).toEqual(expected)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,6 +1083,10 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -2472,7 +2476,7 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^11.12.0, jsdom@^11.5.1:
+jsdom@^11.5.1:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
   dependencies:
@@ -3989,6 +3993,10 @@ strip-eof@^1.0.0:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
+striptags@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/striptags/-/striptags-3.1.1.tgz#c8c3e7fdd6fb4bb3a32a3b752e5b5e3e38093ebd"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Intent

Budou outputs a simple HTML structure that can easily be implemented with simple string concatenation. This is more performant and means we don't have to rely on a heavy library that emulates the DOM. 

The only concern is we need to be vigilant around escaping user input which in this case is the chunk words returned by API. Currently using lighter libraries [`striptags`](https://github.com/ericnorris/striptags) and [`escape-html`](https://github.com/component/escape-html) to achieve this.

## Difference
```js
// Benchmarking with and without JSDOM, useCache=false (Mocking API Calls)
// Result:
BudouWithJsdom#parse x 533 ops/sec ±4.08% (70 runs sampled)
BudouNoJsdom#parse x 18,908 ops/sec ±1.80% (77 runs sampled)
Fastest is BudouNoJsdom#parse
```